### PR TITLE
Remove redundant function call

### DIFF
--- a/js/prepare.js
+++ b/js/prepare.js
@@ -10,9 +10,6 @@ var alertBox = document.getElementById("alertBox");
 var alertMsg = document.getElementById("alertMsg");
 var nbAlerts = 0;  // The number of alerts triggered
 
-// Show loading
-loading();
-
 // Get username from URL parameters
 var username = getUrlVars()['name'];
 


### PR DESCRIPTION
The loader is shown by default. Remove the function call in prepare.js that
shows it.